### PR TITLE
Re-specify the spec.

### DIFF
--- a/peps/pep-0805.rst
+++ b/peps/pep-0805.rst
@@ -229,21 +229,10 @@ Syntax restrictions
 ~~~~~~~~~~~~~~~~~~~
 
 The soft keyword is only allowed at the global (module) level, **not** inside
-functions, class bodies, or ``try``/``with`` blocks. Import statements that use the soft keyword
-are *potentially lazy*. In addition, wild card imports will not be supported for lazy
-import semantics by the soft keyword and will instead raise a syntax error. Imports that
-can't be lazy are unaffected by the global lazy imports flag, and instead are always eager.
-
-Specifically:
-
-1. **Module scope only**: Lazy imports are only allowed at module/global scope.
-   Using ``lazy`` inside a function, class body, or any nested scope raises a
-   ``SyntaxError``.
-
-2. **Not in try/with blocks**: Lazy imports are not allowed inside ``try``/``except``
-   or ``with`` block. This raises a ``SyntaxError``.
-
-3. **No wild card imports**: ``lazy from module import *`` raises a ``SyntaxError``.
+functions, class bodies, with ``try``/``with`` blocks, or ``import *``. Import
+statements that use the soft keyword are *potentially lazy*. Imports that
+can't be lazy are unaffected by the global lazy imports flag, and instead
+are always eager.
 
 Examples of syntax errors:
 
@@ -273,9 +262,11 @@ Examples of syntax errors:
 Semantics
 ---------
 
-When the ``lazy`` keyword is used, the import becomes *potentially lazy*. The module
-is not loaded immediately at the import statement; instead, a lazy proxy object is
-created and bound to the name. The actual module is loaded on first use of that name.
+When the ``lazy`` keyword is used, the import becomes *potentially lazy*.
+Unless lazy imports are disabled or suppressed (see below), the module is
+not loaded immediately at the import statement; instead, a lazy proxy object
+is created and bound to the name. The actual module is loaded on first use
+of that name.
 
 Example:
 
@@ -297,13 +288,13 @@ module names (strings) to make *potentially lazy* (as if the ``lazy`` keyword wa
 used). This attribute is checked on each ``import`` statement to determine whether
 the import should be made *potentially lazy*.
 
-The ``__lazy_modules__`` attribute provides a compatibility mechanism for libraries
-that need to support both Python 3.15+ (with native lazy import support) and older
-versions. When ``__lazy_modules__`` is defined, the specified imports will be
-*potentially lazy* on Python 3.15+, but will fall back to eager imports on older
-Python versions that don't recognize this mechanism. The attribute should be
-defined at module level before the import statements it affects, though it is
-technically evaluated on each import.
+The normal (non-lazy) import statement will check the global lazy imports
+flag. If it is "enabled", all imports are *potentially lazy* (except for
+imports that can't be lazy, as mentioned above.)
+
+If the global lazy imports flag is set to "disabled", no *potentially lazy*
+import is ever imported lazily, and the behavior is equivalent to a regular
+import statement: the import is *eager* (as if the lazy keyword was not used).
 
 For a *potentially lazy* import, the lazy imports filter (if set) is called with
 the name of the module doing the import, the name of the module being
@@ -327,11 +318,11 @@ object, and if so, returns a lazy object for each name instead.
 The end result of this process is that lazy imports (regardless of how they
 are enabled) result in lazy objects being assigned to global variables.
 
-Lazy module objects do not appear in ``sys.modules``, just the
-``sys.lazy_modules`` set. Lazy objects should only end up stored in global
-variables, and the common ways to access those variables (regular variable
-access, module attributes) will resolve lazy imports ("reify") and replace
-them when they're accessed.
+Lazy module objects do not appear in ``sys.modules``, they're just listed in
+the ``sys.lazy_modules`` set. Under normal operation lazy objects should
+only end up stored in global variables, and the common ways to access those
+variables (regular variable access, module attributes) will resolve lazy
+imports ("reify") and replace them when they're accessed.
 
 It is still possible to expose lazy objects through other means, like
 debuggers. This is not considered a problem.
@@ -389,7 +380,7 @@ This exception chaining clearly shows: (1) where the lazy import was defined,
 the error.
 
 Reification does **not** automatically occur when a module that was previously lazily
-imported is subsequently eagerly imported. Reification also does **not** immediately
+imported is subsequently eagerly imported. Reification does **not** immediately
 resolve all lazy objects (e.g. ``lazy from`` statements) that referenced the module.
 It **only** resolves the lazy object being accessed.
 
@@ -418,13 +409,12 @@ Example using ``__dict__`` from external code:
   print('json' in sys.modules)  # True - reified by __dict__ access
   print(type(d['json']))  # <class 'module'>
 
-However, calling ``globals()`` does **not** trigger
-reification — it returns the module's dictionary, and accessing lazy objects through
-that dictionary still returns lazy proxy objects that need to be reified upon use.
-
-More indirect ways of accessing arbitrary globals (e.g. inspecting
-``frame.f_globals``) do **not** reify all the objects. A lazy object can be
-resolved explicitly by calling the ``get`` method.
+However, calling ``globals()`` does **not** trigger reification — it returns
+the module's dictionary, and accessing lazy objects through that dictionary
+still returns lazy proxy objects that need to be manually reified upon use.
+A lazy object can be resolved explicitly by calling the ``get`` method.
+Other, more indirect ways of accessing arbitrary globals (e.g. inspecting
+``frame.f_globals``) also do **not** reify all the objects.
 
 Example using ``globals()``:
 
@@ -459,12 +449,12 @@ instruction checks whether its source is a lazy import (``PyLazyImport_CheckExac
 and creates a lazy object for the attribute rather than accessing it immediately.
 
 When a lazy object is accessed, it must be reified. The ``LOAD_GLOBAL`` instruction
-(used in function scopes) and ``LOAD_NAME`` instruction (used at module level) both
+(used in function scopes) and ``LOAD_NAME`` instruction (used at module and class level) both
 check whether the object being loaded is a lazy import. If so, they call
 ``_PyImport_LoadLazyImportTstate()`` to perform the actual import and store the
 module in ``sys.modules``.
 
-This check incurs a small cost on each access. However, Python's adaptive interpreter
+This check incurs a very small cost on each access. However, Python's adaptive interpreter
 can specialize ``LOAD_GLOBAL`` after observing that a lazy import has been reified.
 After several executions, ``LOAD_GLOBAL`` becomes ``LOAD_GLOBAL_MODULE``, which
 accesses the module dictionary directly without checking for lazy imports.


### PR DESCRIPTION
Tighten up the spec by removing reiterations and explanations that belong in rationale (and usually already are); the spec should be purely spec. (The examples are already borderline, but they don't fit easily in the rationale either.)