### PR TITLE
Add an example for __lazy_modules__ on first description

### DIFF
--- a/peps/pep-0810.rst
+++ b/peps/pep-0810.rst
@@ -295,6 +295,16 @@ The normal (non-lazy) import statement will check the global lazy imports
 flag. If it is "enabled", all imports are *potentially lazy* (except for
 imports that can't be lazy, as mentioned above.)
 
+Example:
+
+.. code-block:: python
+
+    __lazy_modules__ = ["json"]
+    import json
+    print('json' in sys.modules)  # False
+    result = json.dumps({"hello": "world"})
+    print('json' in sys.modules)  # True
+
 If the global lazy imports flag is set to "disabled", no *potentially lazy*
 import is ever imported lazily, and the behavior is equivalent to a regular
 import statement: the import is *eager* (as if the lazy keyword was not used).


### PR DESCRIPTION
When I first read this, I thought I understood it, but had to search for the Q&A section to see a full example. I think it's better to show a brief example where it's first mentioned.